### PR TITLE
V0.70

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 
 Full changelog for PHP Quill Renderer
 
+## v0.70.0 - 2017-04-19
+
+* Added the ability to set the HTML tag for the following Quill attributes, bold, italic, script, strike and underline. [Feature]
+* Minor rework to Quill class to allow options to be set, parse() was being called before the new option value was being set. 
+* Updated readme, now shows direct usage example.
+
 ## v0.60.1 - 2017-04-12
 
 * HTML parser no longer checks against HTML tags directly (h1, h2 etc), uses tag type. [Bugfix]

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Created for use in [Dlayer](https://github.com/Dlayer/dlayer) but works as a sta
 The easiest way to use the renderer is with composer. ```composer require deanblackborough/php-quill-renderer```, 
 alternatively include the classes in src/ in your library.
  
-## Usage
+## Usage, using Quill API
 ```
 try {
     $quill = new \DBlackborough\Quill($deltas, 'HTML');
@@ -26,6 +26,16 @@ try {
 } catch (\Exception $e) {
     echo $e->getMessage();
 }
+```
+
+## Usage, direct
+```
+$parser = new \DBlackborough\Quill\Parser\Html();
+$parser->load($deltas);
+$parser->parse();
+
+$renderer = new \DBlackborough\Quill\Renderer\Html($parser->content());
+echo $renderer->render();
 ```
 
 ## Options
@@ -57,3 +67,5 @@ Header | `<h[n]>`
 * Improved newline and paragraph support
 * External images
 * Remaining toolbar options
+* Missing tests (options)
+* Markdown support

--- a/src/DBlackborough/Quill.php
+++ b/src/DBlackborough/Quill.php
@@ -49,9 +49,23 @@ class Quill
         if ($this->parser->load($deltas) === false) {
             throw new \Exception('Failed to load deltas json');
         }
+    }
 
-        if ($this->parser->parse() !== true) {
-            throw new \Exception('Failed to parse delta');
+    /**
+     * Set a new attribute option
+     *
+     * @param string $option Attribute option to replace
+     * @param mixed $value New Attribute option value
+     *
+     * @return boolean
+     * @throws \Exception
+     */
+    public function setAttributeOption($option, $value)
+    {
+        if (is_a($this->parser, '\DBlackborough\Quill\Parser') === true) {
+            return $this->parser->setAttributeOption($option, $value);
+        } else {
+            throw new \Exception('Parser not instantiated, can only set options after instantiating object');
         }
     }
 
@@ -63,6 +77,10 @@ class Quill
      */
     public function render()
     {
+        if ($this->parser->parse() !== true) {
+            throw new \Exception('Failed to parse delta');
+        }
+
         switch ($this->format) {
             case 'HTML':
                 $this->renderer = new \DBlackborough\Quill\Renderer\Html($this->parser->content());

--- a/src/DBlackborough/Quill/Parser.php
+++ b/src/DBlackborough/Quill/Parser.php
@@ -40,25 +40,40 @@ abstract class Parser
     /**
      * Renderer constructor.
      *
-     * @param array @options Options data array, if empty default options are used
+     * @param array $options Options data array, if empty default options are used
+     * @param array $block_element Block element to use, if empty default is used
      */
-    public function __construct(array $options = array())
+    public function __construct(array $options = array(), $block_element = null)
     {
         $this->content = array();
 
         if (count($options) === 0) {
-            $options = $this->defaultOptions();
+            $options = $this->defaultAttributeOptions();
         }
 
-        $this->setOptions($options);
+        $this->setAttributeOptions($options);
+
+        $block_options = $this->defaultBlockElementOption();
+        if ($block_element !== null) {
+            $block_options['tag'] = $block_element;
+        }
+
+        $this->setBlockOptions($this->defaultBlockElementOption());
     }
 
     /**
-     * Set default options for renderer
+     * Set the default options for the parser/renderer
      *
      * @return array
      */
-    abstract protected function defaultOptions();
+    abstract protected function defaultAttributeOptions();
+
+    /**
+     * Set the default block element for the parser/renderer
+     *
+     * @return array
+     */
+    abstract protected function defaultBlockElementOption();
 
     /**
      * Check to see if the requested attribute is valid, needs to be a known attribute and have an option set
@@ -129,55 +144,31 @@ abstract class Parser
     }
 
     /**
-     * Set the options for the renderer
+     * Set all the attribute options for the parser/renderer
      *
      * @param array $options
      * @return \DBlackborough\Quill\Parser
      */
-    public function setOptions(array $options)
-    {
-        $this->options = $options;
-
-        return $this;
-    }
+    abstract public function setAttributeOptions(array $options);
 
     /**
-     * Set a new option value, replace existing option values
+     * Set the block element for the parser/renderer
      *
-     * @param string $option The Option to replace
-     * @param string $value The new value for the option
+     * @param array $options Block options
      *
      * @return boolean
      */
-    public function setOption($option, $value)
-    {
-        if (array_key_exists($option, $this->options) === true) {
-            $this->options[$option] = $value;
-            return true;
-        } else {
-            return false;
-        }
-    }
+    abstract public function setBlockOptions(array $options);
 
     /**
-     * Set a new attributes option, replace existing attribute option values
+     * Set a new attribute option
      *
      * @param string $option Attribute option to replace
-     * @param string $value New Attribute option value
+     * @param mixed $value New Attribute option value
      *
      * @return boolean
      */
-    public function setAttributeOption($option, $value)
-    {
-        if (array_key_exists('attributes', $this->options) === true &&
-            array_key_exists($option, $this->options['attributes']) === true) {
-
-            $this->options['attributes'][$option]['tag'] = $value;
-            return true;
-        } else {
-            return false;
-        }
-    }
+    abstract public function setAttributeOption($option, $value);
 
     /**
      * @param string $deltas JSON inserts string

--- a/src/DBlackborough/Quill/Parser/Html.php
+++ b/src/DBlackborough/Quill/Parser/Html.php
@@ -16,98 +16,103 @@ class Html extends Parser
     /**
      * Renderer constructor.
      *
-     * @param array @options Options data array, if empty default options are used
+     * @param array $options Options data array, if empty default options are used
+     * @param string $block_element
      */
-    public function __construct(array $options = array())
+    public function __construct(array $options = array(), $block_element = null)
     {
-        parent::__construct($options);
+        parent::__construct($options, $block_element);
     }
 
     /**
-     * Default options for HTML renderer, all options can be overridden, either by setting options in the
-     * constructor or by using the setOption and setAttributeOption methods
+     * Default block element attribute
+     */
+    protected function defaultBlockElementOption()
+    {
+        return array(
+            'tag' => 'p',
+            'type' => 'block'
+        );
+    }
+
+    /**
+     * Default attribute options for the HTML renderer/parser
      *
      * @return array
      */
-    protected function defaultOptions()
+    protected function defaultAttributeOptions()
     {
         return array(
-            'attributes' => array(
-                'bold' => array(
-                    'tag' => 'strong',
-                    'type' => 'inline',
-                ),
-                'header' => array(
-                    '1' => array(
-                        'tag' => 'h1',
-                        'type' => 'block',
-                        'assign' => 'previous'
-                    ),
-                    '2' => array(
-                        'tag' => 'h2',
-                        'type' => 'block',
-                        'assign' => 'previous'
-                    ),
-                    '3' => array(
-                        'tag' => 'h3',
-                        'type' => 'block',
-                        'assign' => 'previous'
-                    ),
-                    '4' => array(
-                        'tag' => 'h4',
-                        'type' => 'block',
-                        'assign' => 'previous'
-                    ),
-                    '5' => array(
-                        'tag' => 'h5',
-                        'type' => 'block',
-                        'assign' => 'previous'
-                    ),
-                    '6' => array(
-                        'tag' => 'h6',
-                        'type' => 'block',
-                        'assign' => 'previous'
-                    ),
-                    '7' => array(
-                        'tag' => 'h7',
-                        'type' => 'block',
-                        'assign' => 'previous'
-                    )
-                ),
-                'italic' => array(
-                    'tag' => 'em',
-                    'type' => 'inline'
-                ),
-                'link' => array(
-                    'tag' => 'a',
-                    'type' => 'inline',
-                    'attributes' => array(
-                        'href' => null
-                    )
-                ),
-                'script' => array(
-                    'sub' => array(
-                        'type' => 'inline',
-                        'tag' => 'sub'
-                    ),
-                    'super' => array(
-                        'type' => 'inline',
-                        'tag' => 'sup'
-                    )
-                ),
-                'strike' => array(
-                    'tag' => 's',
-                    'type' => 'inline'
-                ),
-                'underline' => array(
-                    'tag' => 'u',
-                    'type' => 'inline'
-                ),
+            'bold' => array(
+                'tag' => 'strong',
+                'type' => 'inline',
             ),
-            'block' => array(
-                'tag' => 'p',
-                'type' => 'block'
-            )
+            'header' => array(
+                '1' => array(
+                    'tag' => 'h1',
+                    'type' => 'block',
+                    'assign' => 'previous'
+                ),
+                '2' => array(
+                    'tag' => 'h2',
+                    'type' => 'block',
+                    'assign' => 'previous'
+                ),
+                '3' => array(
+                    'tag' => 'h3',
+                    'type' => 'block',
+                    'assign' => 'previous'
+                ),
+                '4' => array(
+                    'tag' => 'h4',
+                    'type' => 'block',
+                    'assign' => 'previous'
+                ),
+                '5' => array(
+                    'tag' => 'h5',
+                    'type' => 'block',
+                    'assign' => 'previous'
+                ),
+                '6' => array(
+                    'tag' => 'h6',
+                    'type' => 'block',
+                    'assign' => 'previous'
+                ),
+                '7' => array(
+                    'tag' => 'h7',
+                    'type' => 'block',
+                    'assign' => 'previous'
+                )
+            ),
+            'italic' => array(
+                'tag' => 'em',
+                'type' => 'inline'
+            ),
+            'link' => array(
+                'tag' => 'a',
+                'type' => 'inline',
+                'attributes' => array(
+                    'href' => null
+                )
+            ),
+            'script' => array(
+                'sub' => array(
+                    'type' => 'inline',
+                    'tag' => 'sub'
+                ),
+                'super' => array(
+                    'type' => 'inline',
+                    'tag' => 'sup'
+                )
+            ),
+            'strike' => array(
+                'tag' => 's',
+                'type' => 'inline'
+            ),
+            'underline' => array(
+                'tag' => 'u',
+                'type' => 'inline'
+            ),
         );
     }
 
@@ -390,5 +395,42 @@ class Html extends Parser
                 }
             }
         }
+    }
+
+    /**
+     * Set all the attribute options for the parser/renderer
+     *
+     * @param array $options
+     *
+     * @return void
+     */
+    public function setAttributeOptions(array $options)
+    {
+        $this->options['attributes'] = $options;
+    }
+
+    /**
+     * Set the block element for the parser/renderer
+     *
+     * @param array $options Block element options
+     *
+     * @return void
+     */
+    public function setBlockOptions(array $options)
+    {
+        $this->options['block'] = $options;
+    }
+
+    /**
+     * Set a new attribute option
+     *
+     * @param string $option Attribute option to replace
+     * @param mixed $value New Attribute option value
+     *
+     * @return boolean
+     */
+    public function setAttributeOption($option, $value)
+    {
+        // TODO: Implement setAttributeOption() method.
     }
 }

--- a/src/DBlackborough/Quill/Parser/Html.php
+++ b/src/DBlackborough/Quill/Parser/Html.php
@@ -3,6 +3,7 @@
 namespace DBlackborough\Quill\Parser;
 
 use DBlackborough\Quill\Parser;
+use PHPUnit\Runner\Exception;
 
 /**
  * Parser for HTML, parses the deltas to generate a content array for  deltas into a html redy array
@@ -422,15 +423,61 @@ class Html extends Parser
     }
 
     /**
+     * Validate the option request and set the value
+     *
+     * @param string $option Attribute option to replace
+     * @param mixed $value New Attribute option value
+     *
+     * @return true
+     * @throws \Exception
+     */
+    private function validateAndSetAttributeOption($option, $value)
+    {
+        if (is_array($value) === true &&
+            array_key_exists('tag', $value) === true &&
+            array_key_exists('type', $value) === true &&
+            in_array($value['type'], array('inline', 'block')) === true) {
+
+            $this->options['attributes'][$option] = $value;
+
+            return true;
+        } else if (is_string($value) === true) {
+            $this->options['attributes'][$option]['tag'] = $value;
+
+            return true;
+        } else {
+            if (is_array($value) === true) {
+                throw new \Exception('setAttributeOption() value should be an array with two indexes, tag and type');
+            } else {
+                throw new \Exception('setAttributeOption() value should be an array with two indexes, tag and type');
+            }
+        }
+    }
+
+    /**
      * Set a new attribute option
      *
      * @param string $option Attribute option to replace
      * @param mixed $value New Attribute option value
      *
      * @return boolean
+     * @throws Exception
      */
     public function setAttributeOption($option, $value)
     {
-        // TODO: Implement setAttributeOption() method.
+        switch ($option) {
+            case 'bold':
+            case 'italic':
+            case 'script':
+            case 'strike':
+            case 'underline':
+                return $this->validateAndSetAttributeOption($option, $value);
+                break;
+            case 'header':
+            case 'link':
+                return false;
+                break;
+
+        }
     }
 }


### PR DESCRIPTION
* Added the ability to set the HTML tag for the following Quill attributes, bold, italic, script, strike and underline. [Feature]
* Minor rework to Quill class to allow options to be set, parse() was being called before the new option value was being set. 
* Updated readme, now shows direct usage example.