### PR TITLE
fix name attribute unordered to bullet in list

### DIFF
--- a/src/Parser/Html.php
+++ b/src/Parser/Html.php
@@ -102,7 +102,7 @@ class Html extends Parse
                     'assign' => 'previous',
                     'parent_tag' => 'ol'
                 ),
-                'unordered' => array(
+                'bullet' => array(
                     'tag' => 'li',
                     'type' => 'block',
                     'assign' => 'previous',

--- a/src/Parser/Parse.php
+++ b/src/Parser/Parse.php
@@ -118,7 +118,7 @@ abstract class Parse
             case 'list':
                 if (array_key_exists('attributes', $this->options) === true &&
                     array_key_exists($attribute, $this->options['attributes']) === true &&
-                    in_array($value, array('ordered', 'unordered')) === true) {
+                    in_array($value, array('ordered', 'bullet')) === true) {
 
                     $valid = true;
                 }

--- a/tests/ListTest.php
+++ b/tests/ListTest.php
@@ -17,9 +17,9 @@ final class ListTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals($expected, $quill->render());
     }
 
-    public function testSimpleUnorderedList()
+    public function testSimpleBulletList()
     {
-        $delta = '{"ops":[{"insert":"Item 1"},{"attributes":{"list":"unordered"},"insert":"\n"},{"insert":"Item 2"},{"attributes":{"list":"unordered"},"insert":"\n"},{"insert":"Item 3"},{"attributes":{"list":"unordered"},"insert":"\n"}]}';
+        $delta = '{"ops":[{"insert":"Item 1"},{"attributes":{"list":"bullet"},"insert":"\n"},{"insert":"Item 2"},{"attributes":{"list":"bullet"},"insert":"\n"},{"insert":"Item 3"},{"attributes":{"list":"bullet"},"insert":"\n"}]}';
         $expected = '<ul><li>Item 1</li><li>Item 2</li><li>Item 3</li></ul>';
 
         $quill = new \DBlackborough\Quill\Render($delta);


### PR DESCRIPTION
```json 
{
		"ops": [
		{
			"insert": "test 1"
		}, 
		{
			"attributes": {
				"list": "bullet"
			},
			"insert": "\n"
		}, 
		{
			"insert": "test 2"
		}, 
		{
			"attributes": {
				"list": "bullet"
			},
			"insert": "\n"
		}, 
		{
			"insert": "test 3"
		}, 
		{
			"attributes": {
				"list": "bullet"
			},
			"insert": "\n"
		}]
};