### PR TITLE
v3.01.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@
 
 Full changelog for PHP Quill Renderer
 
+## v3.01.0 - 2018-05-10
+
+* `Parser::load()` wasn't resetting the deltas array, thanks [tominventisbe](https://github.com/tominventisbe).
+* Added `CompoundImage` delta, `Compound` delta was incorrectly trying to handle images, thanks [tominventisbe](https://github.com/tominventisbe).
+* The `CompoundImage` delta now assigns all defined attributes to the `img` tag.
+* Renamed the `CompositeTest`, now `CompoundTest`, new name more closely matches what I am testing.
+* Added credit to [Mark Davison](https://github.com/markdavison) - Missing in the v3.00.0 release.
+
 ## v3.00.0 - 2018-05-08
 
 v3.00.0 is an almost complete rewrite of v2.03.1, the new design is flexible and supports all the features of the 
@@ -10,7 +18,7 @@ previous versions without any blatant hacks, no more methods named checkLastItem
 removeRedundantParentTags(), the renderer is simpler because it just needs to iterate over a Deltas array.
 
 There was no change to the API. However, if you use it by calling the parser and renderer classes directly I renamed 
-one method, \DBlackborough\Quill\Parser\HTML::content() is now \DBlackborough\Quill\Parser\HTML::deltas().
+one method, `\DBlackborough\Quill\Parser\HTML::content()` is now `\DBlackborough\Quill\Parser\HTML::deltas()`.
 
 ## 2.03.1 - 2018-04-15
 

--- a/README.md
+++ b/README.md
@@ -85,5 +85,8 @@ List | `<ul>` `<ol>`
 
 ## Credits
 
-* carlos https://github.com/sald19 [Bugfix] v1.01.0
-* pdiveris https://github.com/pdiveris [Issue #43] v2.03.1 - Null inserts
+* [carlos](https://github.com/sald19) [Bugfix] v1.01.0
+* [pdiveris](https://github.com/pdiveris) [Issue #43] v2.03.1 - Null inserts
+* [Mark Davison](https://github.com/markdavison) - Pushed me in the right direction for v3.00.0
+* [tominventisbe](https://github.com/tominventisbe) [Issue #54] v3.01.0 - Parser::load() does not reset the deltas array
+* [tominventisbe](https://github.com/tominventisbe) [Issue #55] v3.01.0 - Image deltas with multiple attributes incorrectly being passed to Compound delta

--- a/src/Delta/Html/Compound.php
+++ b/src/Delta/Html/Compound.php
@@ -67,6 +67,9 @@ class Compound extends Delta
     /**
      * Pass in an attribute value for conversion
      *
+     * @param string $attribute Attribute name
+     * @param string $value Attribute value to assign
+     *
      * @return Compound
      */
     public function setAttribute($attribute, $value): Compound

--- a/src/Delta/Html/CompoundImage.php
+++ b/src/Delta/Html/CompoundImage.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DBlackborough\Quill\Delta\Html;
+
+/**
+ * Default delta class for compound image inserts, multiple attributes
+ *
+ * @author Dean Blackborough <dean@g3d-development.com>
+ * @copyright Dean Blackborough
+ * @license https://github.com/deanblackborough/php-quill-renderer/blob/master/LICENSE
+ */
+class CompoundImage extends Delta
+{
+    /**
+     * Set the initial properties for the delta
+     *
+     * @param string $insert
+     */
+    public function __construct(string $insert)
+    {
+        $this->insert = $insert;
+    }
+
+    /**
+     * Pass in an attribute value for conversion
+     *
+     * @param string $attribute Attribute name
+     * @param string $value Attribute value to assign
+     *
+     * @return CompoundImage
+     */
+    public function setAttribute($attribute, $value): CompoundImage
+    {
+        $this->attributes[$attribute] = $value;
+
+        return $this;
+    }
+
+    /**
+     * Render the HTML for the specific Delta type
+     *
+     * @return string
+     */
+    public function render(): string
+    {
+        $image_attributes = '';
+        foreach ($this->attributes as $attribute => $value) {
+            $image_attributes .= "{$attribute}=\"{$value}\" ";
+        }
+        return "<img src=\"{$this->insert}\" {$image_attributes}/>";
+    }
+}

--- a/src/Parser/Html.php
+++ b/src/Parser/Html.php
@@ -5,6 +5,7 @@ namespace DBlackborough\Quill\Parser;
 
 use DBlackborough\Quill\Delta\Html\Bold;
 use DBlackborough\Quill\Delta\Html\Compound;
+use DBlackborough\Quill\Delta\Html\CompoundImage;
 use DBlackborough\Quill\Delta\Html\Delta;
 use DBlackborough\Quill\Delta\Html\Header;
 use DBlackborough\Quill\Delta\Html\Image;
@@ -135,7 +136,11 @@ class Html extends Parse
                             }
                         } else {
                             if (count($quill['attributes']) > 0) {
-                                $delta = new Compound($quill['insert']);
+                                if (is_array($quill['insert']) === false) {
+                                    $delta = new Compound($quill['insert']);
+                                } else {
+                                    $delta = new CompoundImage($quill['insert']['image']);
+                                }
                                 foreach ($quill['attributes'] as $attribute => $value) {
                                     $delta->setAttribute($attribute, $value);
 

--- a/src/Parser/Parse.php
+++ b/src/Parser/Parse.php
@@ -54,6 +54,7 @@ abstract class Parse
 
         if (is_array($this->quill_json) === true && count($this->quill_json) > 0) {
             $this->valid = true;
+            $this->deltas = [];
             return true;
         } else {
             return false;

--- a/tests/html/CompoundTest.php
+++ b/tests/html/CompoundTest.php
@@ -7,9 +7,9 @@ require __DIR__ . '../../../vendor/autoload.php';
 use DBlackborough\Quill\Render as QuillRender;
 
 /**
- * Composite tests, multiple attributes and complex deltas
+ * Compound tests, multiple attributes and more complex deltas
  */
-final class CompositeTest extends \PHPUnit\Framework\TestCase
+final class CompoundTest extends \PHPUnit\Framework\TestCase
 {
     private $delta_multiple_attributes = '{
         "ops":[
@@ -53,7 +53,37 @@ final class CompositeTest extends \PHPUnit\Framework\TestCase
         ]
     }';
 
+    private $delta_multiple_unknown_attributes_image = '{
+        "ops": [
+            {
+                "insert": "Text 1 "
+            }, 
+            {
+                "attributes": {
+                    "bold": true
+                },
+                "insert": "assumenda"
+            }, 
+            {
+                "insert": " Text 2.\n\n"
+            }, 
+            {
+                "attributes": {
+                    "width": "214",
+                    "style": "display: inline; float: right; margin: 0px 0px 1em 1em;"
+                },
+                "insert": {
+                    "image": "data:image/png;base64,ImageDataOmittedforSize"
+                }
+            }, 
+            {
+                "insert": "\n\nText 3."
+            }
+        ]
+    }';
+
     private $expected_multiple_attributes = "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed efficitur nibh tempor augue lobortis, nec eleifend velit venenatis. Nullam fringilla dui eget lectus mattis tincidunt. Donec sollicitudin, lacus sed luctus ultricies, <s><em>quam sapien </em></s><s>sollicitudin</s> quam, nec auctor eros felis elementum quam. Fusce vel mollis enim. <strong>Sed ac augue tincidunt,</strong> cursus urna a, tempus ipsum. Donec pretium fermentum erat a <u>elementum</u>. In est odio, mattis sed dignissim sed, porta ac nisl. Nunc et tellus imperdiet turpis placerat tristique nec quis justo. Aenean nisi libero, auctor a laoreet sed, fermentum vel massa. Etiam ultricies leo eget purus tempor dapibus. Integer ac sapien eros. Suspendisse convallis ex.</p>";
+    private $expected_multiple_unknown_attributes_image = '<p>Text 1 <strong>assumenda</strong> Text 2.</p><p><img src="data:image/png;base64,ImageDataOmittedforSize" width="214" style="display: inline; float: right; margin: 0px 0px 1em 1em;" /></p><p>Text 3.</p>';
 
     /**
      * Test a delta with multiple attributes
@@ -73,5 +103,29 @@ final class CompositeTest extends \PHPUnit\Framework\TestCase
         }
 
         $this->assertEquals($this->expected_multiple_attributes, $result, __METHOD__ . ' Multiple attributes failure');
+    }
+
+    /**
+     * Test a delta with multiple unknown attributes ona an image, attributes should be included as is
+     *
+     * @return void
+     * @throws \Exception
+     */
+    public function testUndefinedAttributesOnAnImage()
+    {
+        $result = null;
+
+        try {
+            $quill = new QuillRender($this->delta_multiple_unknown_attributes_image);
+            $result = $quill->render();
+        } catch (\Exception $e) {
+            $this->fail(__METHOD__ . 'failure, ' . $e->getMessage());
+        }
+
+        $this->assertEquals(
+            $this->expected_multiple_unknown_attributes_image,
+            $result,
+            __METHOD__ . ' - Undefined attributes on image failure'
+        );
     }
 }

--- a/tests/html/StockTest.php
+++ b/tests/html/StockTest.php
@@ -12,8 +12,10 @@ use DBlackborough\Quill\Render as QuillRender;
 final class StockTest extends \PHPUnit\Framework\TestCase
 {
     private $delta_null_insert = '{"ops":[{"insert":"Heading 1"},{"insert":null},{"attributes":{"header":1},"insert":"\n"}]}';
+    private $delta_header = '{"ops":[{"insert":"Heading 1"},{"attributes":{"header":1},"insert":"\n"}]}';
 
     private $expected_null_insert = "<h1>Heading 1</h1>";
+    private $expected_header = '<h1>Heading 1</h1>';
 
     /**
      * Test to ensure null insert skipped
@@ -28,6 +30,39 @@ final class StockTest extends \PHPUnit\Framework\TestCase
         try {
             $quill = new QuillRender($this->delta_null_insert);
             $result = $quill->render();
+        } catch (\Exception $e) {
+            $this->fail(__METHOD__ . 'failure, ' . $e->getMessage());
+        }
+
+        $this->assertEquals($this->expected_null_insert, $result, __METHOD__ . ' Null insert skipped failure');
+    }
+
+    /**
+     * Test reusing the parser, multiple json deltas passed is via load, load should reset the deltas array,
+     * didn't in v3.00.0
+     *
+     * @return void
+     * @throws \Exception
+     */
+    public function testMultipleInstancesInScript()
+    {
+        $result = null;
+
+        $parser = new \DBlackborough\Quill\Parser\Html();
+
+        try {
+
+            $parser->load($this->delta_header);
+            $parser->parse();
+
+            $renderer = new \DBlackborough\Quill\Renderer\Html($parser->deltas());
+            $result = $renderer->render();
+
+            $parser->load($this->delta_header);
+            $parser->parse();
+
+            $renderer = new \DBlackborough\Quill\Renderer\Html($parser->deltas());
+            $result = $renderer->render();
         } catch (\Exception $e) {
             $this->fail(__METHOD__ . 'failure, ' . $e->getMessage());
         }

--- a/tests/html/StockTest.php
+++ b/tests/html/StockTest.php
@@ -67,6 +67,6 @@ final class StockTest extends \PHPUnit\Framework\TestCase
             $this->fail(__METHOD__ . 'failure, ' . $e->getMessage());
         }
 
-        $this->assertEquals($this->expected_null_insert, $result, __METHOD__ . ' Null insert skipped failure');
+        $this->assertEquals($this->expected_header, $result, __METHOD__ . ' Multiple load calls failure');
     }
 }


### PR DESCRIPTION
* Parser::load() wasn't resetting the deltas array, thanks [tominventisbe](https://github.com/tominventisbe).
* Added CompoundImage delta, Compound delta was incorrectly trying to handle images, thanks [tominventisbe](https://github.com/tominventisbe).
* The CompoundImage delta now assigns all defined attributes to the <img> tag.
* Renamed the CompositeTest, now CompoundTest, new name more closely matches what I am testing.
* Added credit to [Mark Davison](https://github.com/markdavison) - Missing in the v3.00.0 release.
* PHPDoc corrections