### PR TITLE
Child deltas in Markdown list items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 
 Full changelog for PHP Quill Renderer
 
+## v3.13.3 - 2018-07-04
+
+* The Markdown list parsing now correctly using child deltas and matches the HTML parser.
+* Added additional list tests, Markdown versions of the HTML list tests.
+
 ## v3.13.2 - 2018-07-01
 
 * List parsing code was ignoring previous items that were closed, incorrectly adding them as children.

--- a/src/Delta/Markdown/Delta.php
+++ b/src/Delta/Markdown/Delta.php
@@ -19,4 +19,30 @@ abstract class Delta extends BaseDelta
      * @var string The token to use for markdown
      */
     protected $token;
+
+    protected $new_line = false;
+
+    /**
+     * Return whether or not the insert ends with a new line
+     *
+     * @return boolean
+     */
+    public function newLine(): bool
+    {
+        return $this->new_line;
+    }
+
+    /**
+     * Set the new line state
+     *
+     * @return Delta
+     */
+    public function setNewLine(): Delta
+    {
+        if (preg_match("/[\n]{1}/", $this->insert) !== 0) {
+            $this->new_line = true;
+        }
+
+        return $this;
+    }
 }

--- a/src/Delta/Markdown/ListItem.php
+++ b/src/Delta/Markdown/ListItem.php
@@ -66,10 +66,22 @@ class ListItem extends Delta
      */
     public function render(): string
     {
+        $output = '';
+
         if ($this->token === null) {
-            return $this->counter . ". " . trim($this->insert) . "\n";
+            $output .= $this->counter . ". ";
         } else {
-            return $this->token . trim($this->insert) . "\n";
+            $output .= $this->token;
         }
+
+        if ($this->hasChildren() === true) {
+            foreach ($this->children() as $child) {
+                $output .= $child->render();
+            }
+        }
+
+        $output .= $this->insert;
+
+        return $output;
     }
 }

--- a/tests/attributes/markdown/ListTest.php
+++ b/tests/attributes/markdown/ListTest.php
@@ -14,6 +14,21 @@ final class ListTest extends \PHPUnit\Framework\TestCase
 {
     private $delta_ordered = '{"ops":[{"insert":"Item 1"},{"attributes":{"list":"ordered"},"insert":"\n"},{"insert":"Item 2"},{"attributes":{"list":"ordered"},"insert":"\n"},{"insert":"Item 3"},{"attributes":{"list":"ordered"},"insert":"\n"}]}';
     private $delta_unordered = '{"ops":[{"insert":"Item 1"},{"attributes":{"list":"bullet"},"insert":"\n"},{"insert":"Item 2"},{"attributes":{"list":"bullet"},"insert":"\n"},{"insert":"Item 3"},{"attributes":{"list":"bullet"},"insert":"\n"}]}';
+    private $delta_list_with_attribute = '{
+        "ops":[
+            {"insert":"List item 1"},
+            {"attributes":{"list":"bullet"},"insert":"\n"},
+            {"insert":"List "},
+            {"attributes":{"bold":true},"insert":"item"},
+            {"insert":" 2"},
+            {"attributes":{"list":"bullet"},"insert":"\n"},
+            {"insert":"List item 2"},
+            {"attributes":{"list":"bullet"},"insert":"\n"}
+        ]
+    }';
+    private $delta_single_item_list_bold = '{"ops":[{"attributes":{"bold":true},"insert":"List item 1"},{"attributes":{"list":"ordered"},"insert":"\n"}]}';
+    private $delta_single_item_list_italic = '{"ops":[{"attributes":{"italic":true},"insert":"List item 1"},{"attributes":{"list":"ordered"},"insert":"\n"}]}';
+    private $delta_single_item_list_link = '{"ops":[{"attributes":{"link":"link"},"insert":"List item 1"},{"attributes":{"list":"ordered"},"insert":"\n"}]}';
 
     private $expected_ordered = '1. Item 1
 2. Item 2
@@ -23,6 +38,12 @@ final class ListTest extends \PHPUnit\Framework\TestCase
 * Item 2
 * Item 3
 ';
+    private $expected_list_with_attribute = '* List item 1
+* List **item** 2
+* List item 2';
+    private $expected_single_item_list_bold = '1. **List item 1**';
+    private $expected_single_item_list_italic = '1. *List item 1*';
+    private $expected_single_item_list_link = '1. [List item 1](link)';
 
     /**
      * Ordered list
@@ -70,5 +91,85 @@ final class ListTest extends \PHPUnit\Framework\TestCase
             $result,
             __METHOD__ . ' Unordered list failure'
         );
+    }
+
+    /**
+     * Unordered list
+     *
+     * @return void
+     * @throws \Exception
+     */
+    public function testListWithAttribute()
+    {
+        $result = null;
+
+        try {
+            $quill = new QuillRender($this->delta_list_with_attribute, OPTIONS::FORMAT_MARKDOWN);
+            $result = $quill->render();
+        } catch (\Exception $e) {
+            $this->fail(__METHOD__ . 'failure, ' . $e->getMessage());
+        }
+
+        $this->assertEquals($this->expected_list_with_attribute, trim($result), __METHOD__ . ' Unordered list failure');
+    }
+
+    /**
+     * Single item list, entire list item bold
+     *
+     * @return void
+     * @throws \Exception
+     */
+    public function testSingleListItemBold()
+    {
+        $result = null;
+
+        try {
+            $quill = new QuillRender($this->delta_single_item_list_bold, OPTIONS::FORMAT_MARKDOWN);
+            $result = $quill->render();
+        } catch (\Exception $e) {
+            $this->fail(__METHOD__ . 'failure, ' . $e->getMessage());
+        }
+
+        $this->assertEquals($this->expected_single_item_list_bold, trim($result), __METHOD__ . ' Single list item failure');
+    }
+
+    /**
+     * Single item list, entire list item italic
+     *
+     * @return void
+     * @throws \Exception
+     */
+    public function testSingleListItemItalic()
+    {
+        $result = null;
+
+        try {
+            $quill = new QuillRender($this->delta_single_item_list_italic, OPTIONS::FORMAT_MARKDOWN);
+            $result = $quill->render();
+        } catch (\Exception $e) {
+            $this->fail(__METHOD__ . 'failure, ' . $e->getMessage());
+        }
+
+        $this->assertEquals($this->expected_single_item_list_italic, trim($result), __METHOD__ . ' Single list item failure');
+    }
+
+    /**
+     * Single item list, entire list item a link
+     *
+     * @return void
+     * @throws \Exception
+     */
+    public function testSingleListItemLink()
+    {
+        $result = null;
+
+        try {
+            $quill = new QuillRender($this->delta_single_item_list_link, OPTIONS::FORMAT_MARKDOWN);
+            $result = $quill->render();
+        } catch (\Exception $e) {
+            $this->fail(__METHOD__ . 'failure, ' . $e->getMessage());
+        }
+
+        $this->assertEquals($this->expected_single_item_list_link, trim($result), __METHOD__ . ' Single list item failure');
     }
 }

--- a/tests/composite/markdown/ListTest.php
+++ b/tests/composite/markdown/ListTest.php
@@ -13,12 +13,30 @@ use DBlackborough\Quill\Render as QuillRender;
 final class ListTest extends \PHPUnit\Framework\TestCase
 {
     private $delta_paragraph_then_list = '{"ops":[{"insert":"This is a single line of text.\nBullet 1"},{"attributes":{"list":"bullet"},"insert":"\n"},{"insert":"Bullet 2"},{"attributes":{"list":"bullet"},"insert":"\n"},{"insert":"Bullet 3"},{"attributes":{"list":"bullet"},"insert":"\n"}]}';
+    private $delta_paragraph_then_list_then_paragraph = '{"ops":[{"insert":"This is a paragraph.\n\nList item 1"},{"attributes":{"list":"bullet"},"insert":"\n"},{"insert":"List item 2 "},{"attributes":{"list":"bullet"},"insert":"\n"},{"insert":"List item 3"},{"attributes":{"list":"bullet"},"insert":"\n"},{"insert":"\nThis is another paragraph\n"}]}';
+    private $delta_paragraph_then_list_then_paragraph_final_list_character_bold = '{"ops":[{"insert":"This is a paragraph.\n\nList item 1"},{"attributes":{"list":"ordered"},"insert":"\n"},{"insert":"List item 2"},{"attributes":{"list":"ordered"},"insert":"\n"},{"insert":"List item "},{"attributes":{"bold":true},"insert":"3"},{"attributes":{"list":"ordered"},"insert":"\n"},{"insert":"\nThis is another paragraph.\n"}]}';
 
     /** @var string Not keen on the new line in this result, will deal with it at ome point  */
     private $expected_paragraph_then_list = 'This is a single line of text.
 * Bullet 1
 * Bullet 2
 * Bullet 3';
+
+    private $expected_paragraph_then_list_then_paragraph = 'This is a paragraph.
+
+* List item 1
+* List item 2 
+* List item 3
+
+This is another paragraph';
+
+    private $expected_paragraph_then_list_then_paragraph_final_list_character_bold = 'This is a paragraph.
+
+1. List item 1
+2. List item 2
+3. List item **3**
+
+This is another paragraph.';
 
     /**
      * Test a paragraph followed by a list
@@ -44,6 +62,60 @@ final class ListTest extends \PHPUnit\Framework\TestCase
             $this->expected_paragraph_then_list,
             trim($result),
             __METHOD__ . ' Paragraph then list failure'
+        );
+    }
+
+    /**
+     * Test a paragraph followed by a list and then a final paragraph
+     *
+     * @return void
+     * @throws \Exception
+     */
+    public function testParagraphThenListTheParagraph()
+    {
+        $result = null;
+
+        try {
+            $quill = new QuillRender(
+                $this->delta_paragraph_then_list_then_paragraph,
+                OPTIONS::FORMAT_MARKDOWN
+            );
+            $result = $quill->render();
+        } catch (\Exception $e) {
+            $this->fail(__METHOD__ . 'failure, ' . $e->getMessage());
+        }
+
+        $this->assertEquals(
+            $this->expected_paragraph_then_list_then_paragraph,
+            trim($result),
+            __METHOD__ . ' Paragraph then list then paragraph failure'
+        );
+    }
+
+    /**
+     * Test a paragraph followed by a list and then a final paragraph, the final character in the list is bold
+     *
+     * @return void
+     * @throws \Exception
+     */
+    public function testParagraphThenListTheParagraphPlusBoldAttribute()
+    {
+        $result = null;
+
+        try {
+            $quill = new QuillRender(
+                $this->delta_paragraph_then_list_then_paragraph_final_list_character_bold,
+                OPTIONS::FORMAT_MARKDOWN
+            );
+            $result = $quill->render();
+        } catch (\Exception $e) {
+            $this->fail(__METHOD__ . 'failure, ' . $e->getMessage());
+        }
+
+        $this->assertEquals(
+            $this->expected_paragraph_then_list_then_paragraph_final_list_character_bold,
+            trim($result),
+            __METHOD__ . ' Paragraph then list then paragraph failure'
         );
     }
 }


### PR DESCRIPTION
* The Markdown list parsing now correctly using child deltas and matches the HTML parser.
* Added additional list tests, Markdown versions of the HTML list tests.