### PR TITLE
Remove duplication in parsers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 
 Full changelog for PHP Quill Renderer
 
+## v3.13.4 - 2018-07-09
+
+* Removed duplication in HTMl and Markdown parser, moved similar logic to the base parser class.
+* Updated composer dependencies.
+* Added additional Quill info to README.
+
 ## v3.13.3 - 2018-07-04
 
 * The Markdown list parsing now correctly using child deltas and matches the HTML parser.

--- a/README.md
+++ b/README.md
@@ -11,8 +11,11 @@ Render quill insert deltas to HTML and Markdown
 
 ## Description
 
-Quill deltas renderer, converts deltas to HTML and Markdown, the Quill attributes 
-supported are listed in the table below, the goal is to eventually support every Quill feature.
+[Quill](https://github.com/quilljs/quill)  deltas renderer, converts deltas to HTML and Markdown, the  
+[Quill](https://github.com/quilljs/quill) attributes supported are listed in the table below, the goal is to 
+eventually support every Quill feature.
+
+[Quill](https://github.com/quilljs/quill) is a modern WYSIWYG editor built for compatibility and extensibility.
 
 ## Planned features
 

--- a/composer.lock
+++ b/composer.lock
@@ -942,16 +942,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "7.2.4",
+            "version": "7.2.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "00bc0b93f0ff4f557e9ea766557fde96da9a03dd"
+                "reference": "400a3836ee549ae6f665323ac3f21e27eac7155f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/00bc0b93f0ff4f557e9ea766557fde96da9a03dd",
-                "reference": "00bc0b93f0ff4f557e9ea766557fde96da9a03dd",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/400a3836ee549ae6f665323ac3f21e27eac7155f",
+                "reference": "400a3836ee549ae6f665323ac3f21e27eac7155f",
                 "shasum": ""
             },
             "require": {
@@ -967,7 +967,7 @@
                 "php": "^7.1",
                 "phpspec/prophecy": "^1.7",
                 "phpunit/php-code-coverage": "^6.0.7",
-                "phpunit/php-file-iterator": "^2.0",
+                "phpunit/php-file-iterator": "^2.0.1",
                 "phpunit/php-text-template": "^1.2.1",
                 "phpunit/php-timer": "^2.0",
                 "sebastian/comparator": "^3.0",
@@ -1022,7 +1022,7 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2018-06-05 03:40:05"
+            "time": "2018-06-21 13:13:39"
         },
         {
             "name": "psr/http-message",
@@ -1168,16 +1168,16 @@
         },
         {
             "name": "sebastian/comparator",
-            "version": "3.0.0",
+            "version": "3.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/comparator.git",
-                "reference": "ed5fd2281113729f1ebcc64d101ad66028aeb3d5"
+                "reference": "591a30922f54656695e59b1f39501aec513403da"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/ed5fd2281113729f1ebcc64d101ad66028aeb3d5",
-                "reference": "ed5fd2281113729f1ebcc64d101ad66028aeb3d5",
+                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/591a30922f54656695e59b1f39501aec513403da",
+                "reference": "591a30922f54656695e59b1f39501aec513403da",
                 "shasum": ""
             },
             "require": {
@@ -1228,7 +1228,7 @@
                 "compare",
                 "equality"
             ],
-            "time": "2018-04-18 13:33:00"
+            "time": "2018-06-14 15:05:28"
         },
         {
             "name": "sebastian/diff",
@@ -1686,16 +1686,16 @@
         },
         {
             "name": "symfony/config",
-            "version": "v4.1.0",
+            "version": "v4.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/config.git",
-                "reference": "5ceefc256caecc3e25147c4e5b933de71d0020c4"
+                "reference": "e57e7b573df9d0eaa8c0152768c708ee7ea2b8e5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/config/zipball/5ceefc256caecc3e25147c4e5b933de71d0020c4",
-                "reference": "5ceefc256caecc3e25147c4e5b933de71d0020c4",
+                "url": "https://api.github.com/repos/symfony/config/zipball/e57e7b573df9d0eaa8c0152768c708ee7ea2b8e5",
+                "reference": "e57e7b573df9d0eaa8c0152768c708ee7ea2b8e5",
                 "shasum": ""
             },
             "require": {
@@ -1745,20 +1745,20 @@
             ],
             "description": "Symfony Config Component",
             "homepage": "https://symfony.com",
-            "time": "2018-05-16 14:33:22"
+            "time": "2018-06-20 11:15:17"
         },
         {
             "name": "symfony/console",
-            "version": "v4.1.0",
+            "version": "v4.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "2d5d973bf9933d46802b01010bd25c800c87c242"
+                "reference": "70591cda56b4b47c55776ac78e157c4bb6c8b43f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/2d5d973bf9933d46802b01010bd25c800c87c242",
-                "reference": "2d5d973bf9933d46802b01010bd25c800c87c242",
+                "url": "https://api.github.com/repos/symfony/console/zipball/70591cda56b4b47c55776ac78e157c4bb6c8b43f",
+                "reference": "70591cda56b4b47c55776ac78e157c4bb6c8b43f",
                 "shasum": ""
             },
             "require": {
@@ -1813,11 +1813,11 @@
             ],
             "description": "Symfony Console Component",
             "homepage": "https://symfony.com",
-            "time": "2018-05-30 07:26:09"
+            "time": "2018-05-31 10:17:53"
         },
         {
             "name": "symfony/filesystem",
-            "version": "v4.1.0",
+            "version": "v4.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/filesystem.git",
@@ -1981,7 +1981,7 @@
         },
         {
             "name": "symfony/stopwatch",
-            "version": "v4.1.0",
+            "version": "v4.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/stopwatch.git",
@@ -2030,7 +2030,7 @@
         },
         {
             "name": "symfony/yaml",
-            "version": "v4.1.0",
+            "version": "v4.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/yaml.git",

--- a/src/Parser/Html.php
+++ b/src/Parser/Html.php
@@ -45,6 +45,9 @@ class Html extends Parse implements ParserSplitInterface, ParserAttributeInterfa
     public function __construct()
     {
         parent::__construct();
+
+
+        $this->class_delta_bold = 'DBlackborough\Quill\Delta\Html\Bold';
     }
 
     /**
@@ -155,21 +158,6 @@ class Html extends Parse implements ParserSplitInterface, ParserAttributeInterfa
         }
 
         return $inserts;
-    }
-
-    /**
-     * Bold Quill attribute, assign the relevant Delta class and set up
-     * the data
-     *
-     * @param array $quill
-     *
-     * @return void
-     */
-    public function attributeBold(array $quill)
-    {
-        if ($quill['attributes'][OPTIONS::ATTRIBUTE_BOLD] === true) {
-            $this->deltas[] = new Bold($quill['insert'], $quill['attributes']);
-        }
     }
 
     /**

--- a/src/Parser/Html.php
+++ b/src/Parser/Html.php
@@ -46,7 +46,13 @@ class Html extends Parse implements ParserSplitInterface, ParserAttributeInterfa
     {
         parent::__construct();
 
-        $this->class_delta_bold = Bold::Class;
+        $this->class_delta_bold = Bold::class;
+        $this->class_delta_header = Header::class;
+        $this->class_delta_image = Image::class;
+        $this->class_delta_insert = Insert::class;
+        $this->class_delta_italic = Italic::class;
+        $this->class_delta_link = Link::class;
+        $this->class_delta_video = Video::class;
     }
 
     /**
@@ -157,58 +163,6 @@ class Html extends Parse implements ParserSplitInterface, ParserAttributeInterfa
         }
 
         return $inserts;
-    }
-
-    /**
-     * Header Quill attribute, assign the relevant Delta class and set up
-     * the data
-     *
-     * @param array $quill
-     *
-     * @return void
-     */
-    public function attributeHeader(array $quill)
-    {
-        if (in_array($quill['attributes'][OPTIONS::ATTRIBUTE_HEADER], array(1, 2, 3, 4, 5, 6, 7)) === true) {
-            $insert = $this->deltas[count($this->deltas) - 1]->getInsert();
-            unset($this->deltas[count($this->deltas) - 1]);
-            $this->deltas[] = new Header($insert, $quill['attributes']);
-            // Reorder the array
-            $this->deltas = array_values($this->deltas);
-        }
-    }
-
-    /**
-     * Italic Quill attribute, assign the relevant Delta class and set up
-     * the data
-     *
-     * @param array $quill
-     *
-     * @return void
-     */
-    public function attributeItalic(array $quill)
-    {
-        if ($quill['attributes'][OPTIONS::ATTRIBUTE_ITALIC] === true) {
-            $this->deltas[] = new Italic($quill['insert'], $quill['attributes']);
-        }
-    }
-
-    /**
-     * Link Quill attribute, assign the relevant Delta class and set up
-     * the data
-     *
-     * @param array $quill
-     *
-     * @return void
-     */
-    public function attributeLink(array $quill)
-    {
-        if (strlen($quill['attributes'][OPTIONS::ATTRIBUTE_LINK]) > 0) {
-            $this->deltas[] = new Link(
-                $quill['insert'],
-                $quill['attributes']
-            );
-        }
     }
 
     /**
@@ -356,18 +310,6 @@ class Html extends Parse implements ParserSplitInterface, ParserAttributeInterfa
     }
 
     /**
-     * Basic Quill insert
-     *
-     * @param array $quill
-     *
-     * @return void
-     */
-    public function insert(array $quill)
-    {
-        $this->deltas[] = new Insert($quill['insert'], $quill['attributes']);
-    }
-
-    /**
      * Multiple attributes set, handle accordingly
      *
      * @param array $quill
@@ -388,30 +330,6 @@ class Html extends Parse implements ParserSplitInterface, ParserAttributeInterfa
 
             $this->deltas[] = $delta;
         }
-    }
-
-    /**
-     * Image, assign to the image Delta
-     *
-     * @param array $quill
-     *
-     * @return void
-     */
-    public function image(array $quill)
-    {
-        $this->deltas[] = new Image($quill['insert']['image']);
-    }
-
-    /**
-     * Video, assign to the video Delta
-     *
-     * @param array $quill
-     *
-     * @return void
-     */
-    public function video(array $quill)
-    {
-        $this->deltas[] = new Video($quill['insert']['video']);
     }
 
     /**

--- a/src/Parser/Html.php
+++ b/src/Parser/Html.php
@@ -46,8 +46,7 @@ class Html extends Parse implements ParserSplitInterface, ParserAttributeInterfa
     {
         parent::__construct();
 
-
-        $this->class_delta_bold = 'DBlackborough\Quill\Delta\Html\Bold';
+        $this->class_delta_bold = Bold::Class;
     }
 
     /**

--- a/src/Parser/Markdown.php
+++ b/src/Parser/Markdown.php
@@ -43,59 +43,13 @@ class Markdown extends Parse implements ParserAttributeInterface
 
         $this->counter = 1;
 
-        $this->class_delta_bold = Bold::Class;
-    }
-
-    /**
-     * Header Quill attribute, assign the relevant Delta class and set up
-     * the data
-     *
-     * @param array $quill
-     *
-     * @return void
-     */
-    public function attributeHeader(array $quill)
-    {
-        if (in_array($quill['attributes'][OPTIONS::ATTRIBUTE_HEADER], array(1, 2, 3, 4, 5, 6, 7)) === true) {
-            $insert = $this->deltas[count($this->deltas) - 1]->getInsert();
-            unset($this->deltas[count($this->deltas) - 1]);
-            $this->deltas[] = new Header($insert, $quill['attributes']);
-            // Reorder the array
-            $this->deltas = array_values($this->deltas);
-        }
-    }
-
-    /**
-     * Italic Quill attribute, assign the relevant Delta class and set up
-     * the data
-     *
-     * @param array $quill
-     *
-     * @return void
-     */
-    public function attributeItalic(array $quill)
-    {
-        if ($quill['attributes'][OPTIONS::ATTRIBUTE_ITALIC] === true) {
-            $this->deltas[] = new Italic($quill['insert'], $quill['attributes']);
-        }
-    }
-
-    /**
-     * Link Quill attribute, assign the relevant Delta class and set up
-     * the data
-     *
-     * @param array $quill
-     *
-     * @return void
-     */
-    public function attributeLink(array $quill)
-    {
-        if (strlen($quill['attributes'][OPTIONS::ATTRIBUTE_LINK]) > 0) {
-            $this->deltas[] = new Link(
-                $quill['insert'],
-                $quill['attributes']
-            );
-        }
+        $this->class_delta_bold = Bold::class;
+        $this->class_delta_header = Header::class;
+        $this->class_delta_image = Image::class;
+        $this->class_delta_insert = Insert::class;
+        $this->class_delta_italic = Italic::class;
+        $this->class_delta_link = Link::class;
+        $this->class_delta_video = Video::class;
     }
 
     /**
@@ -216,18 +170,6 @@ class Markdown extends Parse implements ParserAttributeInterface
     }
 
     /**
-     * Basic Quill insert
-     *
-     * @param array $quill
-     *
-     * @return void
-     */
-    public function insert(array $quill)
-    {
-        $this->deltas[] = new Insert($quill['insert'], $quill['attributes']);
-    }
-
-    /**
      * Multiple attributes set, handle accordingly
      *
      * @param array $quill
@@ -237,30 +179,6 @@ class Markdown extends Parse implements ParserAttributeInterface
     public function compoundInsert(array $quill)
     {
         $this->deltas[] = new Insert($quill['insert']);
-    }
-
-    /**
-     * Image, assign to the image Delta
-     *
-     * @param array $quill
-     *
-     * @return void
-     */
-    public function image(array $quill)
-    {
-        $this->deltas[] = new Image($quill['insert']['image']);
-    }
-
-    /**
-     * Video, assign to the video Delta
-     *
-     * @param array $quill
-     *
-     * @return void
-     */
-    public function video(array $quill)
-    {
-        $this->deltas[] = new Video($quill['insert']['video']);
     }
 
     /**

--- a/src/Parser/Markdown.php
+++ b/src/Parser/Markdown.php
@@ -43,7 +43,7 @@ class Markdown extends Parse implements ParserAttributeInterface
 
         $this->counter = 1;
 
-        $this->class_delta_bold = 'DBlackborough\Quill\Delta\Markdown\Bold';
+        $this->class_delta_bold = Bold::Class;
     }
 
     /**

--- a/src/Parser/Markdown.php
+++ b/src/Parser/Markdown.php
@@ -42,21 +42,8 @@ class Markdown extends Parse implements ParserAttributeInterface
         parent::__construct();
 
         $this->counter = 1;
-    }
 
-    /**
-     * Bold Quill attribute, assign the relevant Delta class and set up
-     * the data
-     *
-     * @param array $quill
-     *
-     * @return void
-     */
-    public function attributeBold(array $quill)
-    {
-        if ($quill['attributes'][OPTIONS::ATTRIBUTE_BOLD] === true) {
-            $this->deltas[] = new Bold($quill['insert'], $quill['attributes']);
-        }
+        $this->class_delta_bold = 'DBlackborough\Quill\Delta\Markdown\Bold';
     }
 
     /**

--- a/src/Parser/Parse.php
+++ b/src/Parser/Parse.php
@@ -52,6 +52,12 @@ abstract class Parse implements ParserInterface
     protected $valid = false;
 
     protected $class_delta_bold;
+    protected $class_delta_header;
+    protected $class_delta_image;
+    protected $class_delta_insert;
+    protected $class_delta_italic;
+    protected $class_delta_link;
+    protected $class_delta_video;
 
     /**
      * Renderer constructor.
@@ -252,8 +258,7 @@ abstract class Parse implements ParserInterface
     }
 
     /**
-     * Bold Quill attribute, assign the relevant Delta class and set up
-     * the data
+     * Bold Quill attribute, assign the relevant Delta class and set up the data
      *
      * @param array $quill
      *
@@ -264,5 +269,90 @@ abstract class Parse implements ParserInterface
         if ($quill['attributes'][OPTIONS::ATTRIBUTE_BOLD] === true) {
             $this->deltas[] = new $this->class_delta_bold($quill['insert'], $quill['attributes']);
         }
+    }
+
+    /**
+     * Header Quill attribute, assign the relevant Delta class and set up the data
+     *
+     * @param array $quill
+     *
+     * @return void
+     */
+    public function attributeHeader(array $quill)
+    {
+        if (in_array($quill['attributes'][OPTIONS::ATTRIBUTE_HEADER], array(1, 2, 3, 4, 5, 6, 7)) === true) {
+            $insert = $this->deltas[count($this->deltas) - 1]->getInsert();
+            unset($this->deltas[count($this->deltas) - 1]);
+            $this->deltas[] = new $this->class_delta_header($insert, $quill['attributes']);
+            // Reorder the array
+            $this->deltas = array_values($this->deltas);
+        }
+    }
+
+    /**
+     * Italic Quill attribute, assign the relevant Delta class and set up the data
+     *
+     * @param array $quill
+     *
+     * @return void
+     */
+    public function attributeItalic(array $quill)
+    {
+        if ($quill['attributes'][OPTIONS::ATTRIBUTE_ITALIC] === true) {
+            $this->deltas[] = new $this->class_delta_italic($quill['insert'], $quill['attributes']);
+        }
+    }
+
+    /**
+     * Link Quill attribute, assign the relevant Delta class and set up the data
+     *
+     * @param array $quill
+     *
+     * @return void
+     */
+    public function attributeLink(array $quill)
+    {
+        if (strlen($quill['attributes'][OPTIONS::ATTRIBUTE_LINK]) > 0) {
+            $this->deltas[] = new $this->class_delta_link(
+                $quill['insert'],
+                $quill['attributes']
+            );
+        }
+    }
+
+    /**
+     * Image, assign to the image Delta
+     *
+     * @param array $quill
+     *
+     * @return void
+     */
+    public function image(array $quill)
+    {
+        $this->deltas[] = new $this->class_delta_image($quill['insert']['image']);
+    }
+
+    /**
+     * Basic Quill insert
+     *
+     * @param array $quill
+     *
+     * @return void
+     */
+    public function insert(array $quill)
+    {
+        $this->deltas[] = new $this->class_delta_insert($quill['insert'], $quill['attributes']);
+    }
+
+    /**
+     * Video, assign to the video Delta
+     *
+     * @param array $quill
+     *
+     * @return void
+     */
+    public function video(array $quill)
+    {
+        $this->deltas[] = new $this->class_delta_video($quill['insert']['video']);
     }
 }

--- a/src/Parser/Parse.php
+++ b/src/Parser/Parse.php
@@ -51,6 +51,8 @@ abstract class Parse implements ParserInterface
      */
     protected $valid = false;
 
+    protected $class_delta_bold;
+
     /**
      * Renderer constructor.
      */
@@ -246,6 +248,21 @@ abstract class Parse implements ParserInterface
             throw new \OutOfRangeException(
                 'Deltas array does not exist for the given index: ' . $index
             );
+        }
+    }
+
+    /**
+     * Bold Quill attribute, assign the relevant Delta class and set up
+     * the data
+     *
+     * @param array $quill
+     *
+     * @return void
+     */
+    public function attributeBold(array $quill)
+    {
+        if ($quill['attributes'][OPTIONS::ATTRIBUTE_BOLD] === true) {
+            $this->deltas[] = new $this->class_delta_bold($quill['insert'], $quill['attributes']);
         }
     }
 }


### PR DESCRIPTION
* Removed duplication in HTMl and Markdown parser, moved similar logic to the base parser class.
* Updated composer dependencies.
* Added additional Quill info to README.