### PR TITLE
Multiple attributes ignored by Markdown parser [Bugfix]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,12 @@
 
 Full changelog for PHP Quill Renderer
 
-## v3.14.0 - 2018-07-xx 
+## v3.14.1 - 2018-08-20
+
+* Multiple attributes ignored by the Markdown and the GitHub Markdown parsers, added two tests to catch regressions.
+* Minor changes to README and composer.json.
+
+## v3.14.0 - 2018-07-10 
 
 * Initial support for GitHub flavoured Markdown, extends Markdown and adds support for strike through text.
 * Added basic escaping for HTML and Markdown.

--- a/README.md
+++ b/README.md
@@ -29,7 +29,9 @@ The easiest way to use the `PHP Quill Renderer` is via composer.
 ```composer require deanblackborough/php-quill-renderer```, 
 alternatively you can include the classes in my src/ directory directly in your library or app.
 
-## Usage via API, single $quill_json
+## Usage
+
+### Via API, single $quill_json
 ```
 try {
     $quill = new \DBlackborough\Quill\Render($quill_json);
@@ -41,7 +43,7 @@ try {
 echo $result;
 ```
 
-## Usage via API, multiple $quill_json, passed in via array
+### Via API, multiple $quill_json, passed in via array
 
 ```
 try {
@@ -57,7 +59,7 @@ echo $result_one;
 echo $result_two;
 ```
 
-## Usage, direct, parse and then render, single $quill_json - updated in v3.10.0
+### Direct, parse and then render, single $quill_json - updated in v3.10.0
 
 ```
 $parser = new \DBlackborough\Quill\Parser\Html();
@@ -68,7 +70,7 @@ $parser->load($quill_json)->parse();
 echo $renderer->load($parser->deltas())->render();
 ```
 
-## Usage, direct, parse and then render, multiple $quill_json - updated in v3.10.0
+### Direct, parse and then render, multiple $quill_json - updated in v3.10.0
 
 ```
 $parser = new \DBlackborough\Quill\Parser\Html();
@@ -120,6 +122,11 @@ echo $renderer->load($parser->deltasByIndex('two'))->render();
 | Image | `<img>` | `![Image](\path\to\image)`
 | Video | `<iframe>` | `![Video](\path\to\video)`
 | List | `<ul>` `<ol>` | `* ` & `[n]`
+
+## Copyright and license
+The [deanblackborough/php-quill-renderer](https://github.com/deanblackborough/php-quill-renderer) library is copyright 
+© Dean Blackborough and [licensed](https://github.com/deanblackborough/php-quill-renderer/blob/master/LICENSE) 
+for use under the MIT License (MIT). 
 
 ## Credits
 

--- a/Tests/Attributes/GitHubMarkdown/TypographyTest.php
+++ b/Tests/Attributes/GitHubMarkdown/TypographyTest.php
@@ -17,10 +17,14 @@ final class TypographyTest extends \PHPUnit\Framework\TestCase
     private $delta_strike = '{"ops":[{"insert":"Lorem ipsum dolor sit amet "},{"attributes":{"strike":true},"insert":"sollicitudin"},{"insert":" quam, nec auctor eros felis elementum quam. Fusce vel mollis enim."}]}';
     private $delta_escape = '{"ops":[{"insert":"What happens if you type *in markdown*.\n"}]}';
 
+    private $delta_compound = '{"ops":[{"insert":"The "},{"attributes":{"italic":true},"insert":"quick"},{"insert":" brown fox "},{"attributes":{"bold":true},"insert":"jumps"},{"insert":" over the "},{"attributes":{"italic":true,"bold":true},"insert":"lazy"},{"insert":" dog..."}]}';
+
     private $expected_bold = 'Lorem ipsum dolor sit amet **sollicitudin** quam, nec auctor eros felis elementum quam. Fusce vel mollis enim.';
     private $expected_italic = 'Lorem ipsum dolor sit amet *sollicitudin* quam, nec auctor eros felis elementum quam. Fusce vel mollis enim.';
     private $expected_strike = 'Lorem ipsum dolor sit amet ~~sollicitudin~~ quam, nec auctor eros felis elementum quam. Fusce vel mollis enim.';
     private $expected_escape = 'What happens if you type \*in markdown\*.';
+
+    private $expected_compound = 'The *quick* brown fox **jumps** over the ***lazy*** dog...';
 
     /**
      * Test bold attribute
@@ -115,6 +119,30 @@ final class TypographyTest extends \PHPUnit\Framework\TestCase
             $this->expected_escape,
             $result,
             __METHOD__ . ' - Escape failure'
+        );
+    }
+
+    /**
+     * Test a delta with a compound attribute
+     *
+     * @return void
+     * @throws \Exception
+     */
+    public function testCompoundAttribute()
+    {
+        $result = null;
+
+        try {
+            $quill = new QuillRender($this->delta_compound, OPTIONS::FORMAT_GITHUB_MARKDOWN);
+            $result = $quill->render();
+        } catch (\Exception $e) {
+            $this->fail(__METHOD__ . 'failure, ' . $e->getMessage());
+        }
+
+        $this->assertEquals(
+            $this->expected_compound,
+            $result,
+            __METHOD__ . ' - Compound attribute failure'
         );
     }
 }

--- a/Tests/Attributes/Markdown/TypographyTest.php
+++ b/Tests/Attributes/Markdown/TypographyTest.php
@@ -15,8 +15,12 @@ final class TypographyTest extends \PHPUnit\Framework\TestCase
     private $delta_bold = '{"ops":[{"insert":"Lorem ipsum dolor sit amet "},{"attributes":{"bold":true},"insert":"sollicitudin"},{"insert":" quam, nec auctor eros felis elementum quam. Fusce vel mollis enim."}]}';
     private $delta_italic = '{"ops":[{"insert":"Lorem ipsum dolor sit amet "},{"attributes":{"italic":true},"insert":"sollicitudin"},{"insert":" quam, nec auctor eros felis elementum quam. Fusce vel mollis enim."}]}';
 
+    private $delta_compound = '{"ops":[{"insert":"The "},{"attributes":{"italic":true},"insert":"quick"},{"insert":" brown fox "},{"attributes":{"bold":true},"insert":"jumps"},{"insert":" over the "},{"attributes":{"italic":true,"bold":true},"insert":"lazy"},{"insert":" dog..."}]}';
+
     private $expected_bold = 'Lorem ipsum dolor sit amet **sollicitudin** quam, nec auctor eros felis elementum quam. Fusce vel mollis enim.';
     private $expected_italic = 'Lorem ipsum dolor sit amet *sollicitudin* quam, nec auctor eros felis elementum quam. Fusce vel mollis enim.';
+
+    private $expected_compound = 'The *quick* brown fox **jumps** over the ***lazy*** dog...';
 
     /**
      * Test bold attribute
@@ -63,6 +67,30 @@ final class TypographyTest extends \PHPUnit\Framework\TestCase
             $this->expected_italic,
             $result,
             __METHOD__ . ' - Italic attribute failure'
+        );
+    }
+
+    /**
+     * Test a delta with a compound attribute
+     *
+     * @return void
+     * @throws \Exception
+     */
+    public function testCompoundAttribute()
+    {
+        $result = null;
+
+        try {
+            $quill = new QuillRender($this->delta_compound, OPTIONS::FORMAT_MARKDOWN);
+            $result = $quill->render();
+        } catch (\Exception $e) {
+            $this->fail(__METHOD__ . 'failure, ' . $e->getMessage());
+        }
+
+        $this->assertEquals(
+            $this->expected_compound,
+            $result,
+            __METHOD__ . ' - Compound attribute failure'
         );
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "deanblackborough/php-quill-renderer",
-    "description": "Render Quill insert deltas to HTML",
+    "description": "Render quill insert deltas to HTML, Markdown and GitHub flavoured Markdown ",
     "autoload": {
         "psr-4" : {
             "DBlackborough\\Quill\\" : "src/"

--- a/src/Delta/Markdown/Compound.php
+++ b/src/Delta/Markdown/Compound.php
@@ -1,0 +1,98 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DBlackborough\Quill\Delta\Markdown;
+
+use DBlackborough\Quill\Options;
+
+/**
+ * Compound Markdown delta, collects all the attributes for a compound insert and returns the generated string
+ *
+ * @author Dean Blackborough <dean@g3d-development.com>
+ * @copyright Dean Blackborough
+ * @license https://github.com/deanblackborough/php-quill-renderer/blob/master/LICENSE
+ */
+class Compound extends Delta
+{
+    /**
+     * @var array Array of Markdown tokens
+     */
+    private $tokens;
+
+    /**
+     * @var array Array of passed in attributes
+     */
+
+    /**
+     * Set the insert for the compound delta insert
+     *
+     * @param string $insert
+     */
+    public function __construct(string $insert)
+    {
+        $this->insert = $insert;
+
+        $this->tokens = [];
+    }
+
+    /**
+     * Pass in an attribute value for conversion
+     *
+     * @param string $attribute Attribute name
+     * @param string $value Attribute value to assign
+     *
+     * @return Compound
+     */
+    public function setAttribute($attribute, $value): Compound
+    {
+        $this->attributes[$attribute] = $value;
+
+        return $this;
+    }
+
+    /**
+     * Convert attributes to tokens
+     */
+    private function tokens(): void
+    {
+        foreach ($this->attributes as $attribute => $value) {
+            switch ($attribute) {
+                case Options::ATTRIBUTE_BOLD:
+                    $this->tokens[] = Options::MARKDOWN_TOKEN_BOLD;
+                    break;
+
+                case Options::ATTRIBUTE_ITALIC:
+                    $this->tokens[] = Options::MARKDOWN_TOKEN_ITALIC;
+                    break;
+
+                default:
+                    break;
+            }
+        }
+    }
+
+    /**
+     * Render the Html for the specific Delta type
+     *
+     * @return string
+     */
+    public function render(): string
+    {
+        $return = '';
+
+        $this->tokens();
+
+        foreach ($this->tokens as $token) {
+            $return .= $token;
+        }
+
+        $return .= $this->escape($this->insert);
+
+        foreach (array_reverse($this->tokens) as $token) {
+            $return .= $token;
+        }
+
+        return $return;
+    }
+}

--- a/src/Parser/Markdown.php
+++ b/src/Parser/Markdown.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace DBlackborough\Quill\Parser;
 
 use DBlackborough\Quill\Delta\Markdown\Bold;
+use DBlackborough\Quill\Delta\Markdown\Compound;
 use DBlackborough\Quill\Delta\Markdown\Delta;
 use DBlackborough\Quill\Delta\Markdown\Header;
 use DBlackborough\Quill\Delta\Markdown\Image;
@@ -178,7 +179,17 @@ class Markdown extends Parse implements ParserAttributeInterface
      */
     public function compoundInsert(array $quill)
     {
-        $this->deltas[] = new Insert($quill['insert']);
+        if (count($quill['attributes']) > 0) {
+            if (is_array($quill['insert']) === false) {
+                $delta = new Compound($quill['insert']);
+
+                foreach ($quill['attributes'] as $attribute => $value) {
+                    $delta->setAttribute($attribute, $value);
+                }
+
+                $this->deltas[] = $delta;
+            }
+        }
     }
 
     /**


### PR DESCRIPTION
* Multiple attributes ignored by the Markdown and the GitHub Markdown parsers, added two tests to catch regressions, closes #98 
* Minor changes to README and composer.json.