### PR TITLE
fix bold + color rendering

### DIFF
--- a/Tests/Combined/Html/BoldColorTest.php
+++ b/Tests/Combined/Html/BoldColorTest.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace DBlackborough\Quill\Tests\Attributes\Html;
+
+require __DIR__ . '../../../../vendor/autoload.php';
+
+use DBlackborough\Quill\Render as QuillRender;
+
+final class BoldColorTest extends \PHPUnit\Framework\TestCase
+{
+    private $delta_bold_text = '{"ops":[{"attributes":{"color":"#66b966","bold":true},"insert":"My Text"}]}';
+
+    private $expected_href = '<p><strong style="color: #66b966">My Text</strong></p>';
+
+    public function testBoldColor()
+    {
+        $result = null;
+
+        try {
+            $quill = new QuillRender($this->delta_bold_text);
+            $result = $quill->render();
+        } catch (\Exception $e) {
+            $this->fail(__METHOD__ . 'failure, ' . $e->getMessage());
+        }
+
+        $this->assertEquals($this->expected_href, trim($result), __METHOD__ . ' BoldColorText');
+    }
+}
+

--- a/src/Delta/Html/Compound.php
+++ b/src/Delta/Html/Compound.php
@@ -104,7 +104,11 @@ class Compound extends Delta
 
         $element_attributes = '';
         foreach ($this->element_attributes as $attribute => $value) {
-            $element_attributes .= "{$attribute}=\"{$value}\" ";
+            if ($attribute == "color") {
+                $element_attributes .= "style=\"{$attribute}: $value\"";
+            } else {
+                $element_attributes .= "{$attribute}=\"{$value}\" ";
+            }
         }
 
         foreach ($this->tags as $i => $tag) {


### PR DESCRIPTION
We had a small problem with this library, it wouldn't render the color css-attribute inside a style attribute on strong-tags, which is a bit inconvenient, because browsers would just ignore the old legacy color attributes when a color was already defined in css.

Basically the color attribute would not overwrite what ever css defined. 

**This is what changed about rendering:**
delta
```json
{"ops":[{"attributes":{"color":"#66b966","bold":true},"insert":"My Text"}]}
```
before
```html
<p><strong color= "#66b966">My Text</strong></p>
```
after
```html
<p><strong style="color: #66b966">My Text</strong></p>
```

The way I Implemented it is probably not the best. I'll gladly improve it upon feedback.

Also I think the Test I wrote should be moved into some other class, but I am unsure in which class.

It would be neat if this could get merged.