### PR TITLE
v3.17.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,13 @@
 
 Full changelog for PHP Quill Renderer
 
-## v3.17.1 - 2019-03-xx
+## v3.17.2 - 2019-03-09
+
+* Additional work to fix [#117](https://github.com/deanblackborough/php-quill-renderer/issues/117),
+allow through any empty insert, some are valid so for now just render what quill wants, I'll 
+add strict mode later to remove what I consider to be the redundant inserts.
+
+## v3.17.1 - 2019-03-07
 
 * Fixed [#117](https://github.com/deanblackborough/php-quill-renderer/issues/117), compound
 deltas not aware of the fact that they can also be links.

--- a/README.md
+++ b/README.md
@@ -18,15 +18,11 @@ supported are listed in the table below, the goal is to eventually support every
 
 ## Planned features
 
-The latest update, v3.16.0, took a while, after receiving many bug reports related 
-to mishandling of newlines I decided to do a minor refactor, mainly splitting the deltas 
-sooner. I'm hoping that by the v3.17.0 release I'll be done and can then concentrate on new features.
-
 If you check the table below you will note that I don't support all of Quills 
 features, that is definitely the plan, however, before I add support for new 
 attributes I want to add a major new feature.
 
-Plugins
+#### Plugins
 
 I'm planning to add support for plugins, all the existing features will become 
 plugins, therefore, based on your particular needs you will be able to disable plugins/deltas 
@@ -37,7 +33,7 @@ the known bugs and completed my planned refactoring I will start work on plugins
 in the v4 branch. 
 
 I will continue to support v3 after the eventual release of v4, some features may 
-be backported, it very much depends on the particular feature. 
+be back-ported, it very much depends on the particular feature. 
 
 ## Installation
  

--- a/Tests/Api/BugTest.php
+++ b/Tests/Api/BugTest.php
@@ -250,6 +250,40 @@ final class BugTest extends \PHPUnit\Framework\TestCase
             }
         ]
     }';
+    private $delta_bug_117_links_deltas_with_attributes_take_2 = '
+    {
+        "ops":[
+            {
+                "attributes":{
+                    "italic":true,
+                    "link":"https://www.amazon.com"
+                },
+                "insert":"Space"
+            },
+            {
+                "insert":" "
+            },
+            {
+                "attributes":{
+                    "bold":true,
+                    "link":"https://www.yahoo.com"
+                },
+                "insert":"removed"
+            },
+            {
+                "insert":" but shoudn\'t"
+            },
+            {
+                "attributes":{
+                    "bold":true
+                },
+                "insert":"."
+            },
+            {
+                "insert":"\n"
+            }
+        ]
+    }';
 
     private $expected_bug_external_3 = '<p>Lorem ipsum
 <br />
@@ -282,6 +316,7 @@ Lorem ipsum
     private $expected_bug_117_links_deltas_with_attributes = '<p>The <a href="https://www.google.com"><em>quick</em></a> brown fox <a href="https://www.google.com"><strong>jumps</strong></a> over t<a href="https://www.google.com">he </a><a href="https://www.google.com"><em><strong>lazy</strong></em></a><a href="https://www.google.com"> do</a>g... <a href="https://www.amazon.com"><em>Space</em></a><a href="https://www.yahoo.com"><strong>removed</strong></a>.
 <br />
 </p>';
+    private $expected_bug_117_links_deltas_with_attributes_take_2 = '<p><a href="https://www.amazon.com"><em>Space</em></a> <a href="https://www.yahoo.com"><strong>removed</strong></a> but shoudn\'t<strong>.</strong></p>';
 
     /**
      * Newlines still proving to be an issue
@@ -403,6 +438,31 @@ Lorem ipsum
 
         $this->assertEquals(
             $this->expected_bug_117_links_deltas_with_attributes,
+            trim($result),
+            __METHOD__ . ' link output incorrect'
+        );
+    }
+
+    /**
+     * Links with attributes not being created correctly, take 2, space issues
+     * Bug report https://github.com/deanblackborough/php-quill-renderer/issues/117
+     *
+     * @return void
+     * @throws \Exception
+     */
+    public function testLinkDeltasWithAdditionalAttributesTake2()
+    {
+        $result = null;
+
+        try {
+            $quill = new QuillRender($this->delta_bug_117_links_deltas_with_attributes_take_2);
+            $result = $quill->render();
+        } catch (\Exception $e) {
+            $this->fail(__METHOD__ . 'failure, ' . $e->getMessage());
+        }
+
+        $this->assertEquals(
+            $this->expected_bug_117_links_deltas_with_attributes_take_2,
             trim($result),
             __METHOD__ . ' link output incorrect'
         );

--- a/Tests/Api/BugTest.php
+++ b/Tests/Api/BugTest.php
@@ -313,10 +313,12 @@ Lorem ipsum
 <p>Some Text.
 <br />
 </p>';
-    private $expected_bug_117_links_deltas_with_attributes = '<p>The <a href="https://www.google.com"><em>quick</em></a> brown fox <a href="https://www.google.com"><strong>jumps</strong></a> over t<a href="https://www.google.com">he </a><a href="https://www.google.com"><em><strong>lazy</strong></em></a><a href="https://www.google.com"> do</a>g... <a href="https://www.amazon.com"><em>Space</em></a><a href="https://www.yahoo.com"><strong>removed</strong></a>.
+    private $expected_bug_117_links_deltas_with_attributes = '<p>The <a href="https://www.google.com"><em>quick</em></a> brown fox <a href="https://www.google.com"><strong>jumps</strong></a> over t<a href="https://www.google.com">he </a><a href="https://www.google.com"><em><strong>lazy</strong></em></a><a href="https://www.google.com"> do</a>g... <a href="https://www.amazon.com"><em>Space</em></a> <a href="https://www.yahoo.com"><strong>removed</strong></a>.
 <br />
 </p>';
-    private $expected_bug_117_links_deltas_with_attributes_take_2 = '<p><a href="https://www.amazon.com"><em>Space</em></a> <a href="https://www.yahoo.com"><strong>removed</strong></a> but shoudn\'t<strong>.</strong></p>';
+    private $expected_bug_117_links_deltas_with_attributes_take_2 = '<p><a href="https://www.amazon.com"><em>Space</em></a> <a href="https://www.yahoo.com"><strong>removed</strong></a> but shoudn\'t<strong>.</strong>
+<br />
+</p>';
 
     /**
      * Newlines still proving to be an issue

--- a/Tests/Combined/Html/HeaderTest.php
+++ b/Tests/Combined/Html/HeaderTest.php
@@ -14,15 +14,19 @@ final class HeaderTest extends \PHPUnit\Framework\TestCase
     private $delta_header_then_text = '{"ops":[{"insert":"This is a heading"},{"attributes":{"header":2},"insert":"\n"},{"insert":"\nNow some normal text.\n"}]}';
     private $delta_header_then_text_then_header = '{"ops":[{"insert":"This is a heading"},{"attributes":{"header":2},"insert":"\n"},{"insert":"\nNow some normal text.\n\nNow another heading"},{"attributes":{"header":1},"insert":"\n"}]}';
 
-    private $expected_header_then_text = "<h2>This is a heading</h2>
-<p>Now some normal text.
+    private $expected_header_then_text = '<h2>This is a heading</h2>
+<p>
 <br />
-</p>";
-    private $expected_header_then_text_then_header = "<h2>This is a heading</h2>
-<p>Now some normal text.
+Now some normal text.
+<br />
+</p>';
+    private $expected_header_then_text_then_header = '<h2>This is a heading</h2>
+<p>
+<br />
+Now some normal text.
 
 </p>
-<h1>Now another heading</h1>";
+<h1>Now another heading</h1>';
 
     /**
      * Test a heading then plain text

--- a/Tests/Combined/Html/ListTest.php
+++ b/Tests/Combined/Html/ListTest.php
@@ -33,7 +33,9 @@ final class ListTest extends \PHPUnit\Framework\TestCase
 <li>List item 2 </li>
 <li>List item 3</li>
 </ul>
-<p>This is another paragraph
+<p>
+<br />
+This is another paragraph
 <br />
 </p>';
 
@@ -45,7 +47,9 @@ final class ListTest extends \PHPUnit\Framework\TestCase
 <li>List item 2</li>
 <li>List item <strong>3</strong></li>
 </ol>
-<p>This is another paragraph.
+<p>
+<br />
+This is another paragraph.
 <br />
 </p>';
 

--- a/Tests/Combined/Html/MixTest.php
+++ b/Tests/Combined/Html/MixTest.php
@@ -154,14 +154,22 @@ final class MixTest extends \PHPUnit\Framework\TestCase
     }';
 
     private $expected_paragraph_after_two_headers = '<h1>Primary Header</h1>
+<p>
+<br />
+</p>
 <h2>Secondary header</h2>
-<p>A paragraph.
+<p>
+<br />
+A paragraph.
 <br />
 </p>';
     private $expected_list_and_header = '<ul>
 <li>Another list</li>
 <li>List item two entry two</li>
 </ul>
+<p>
+<br />
+</p>
 <h4>And now a HEADER</h4>';
     private $expected_multiple_attributes = "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed efficitur nibh tempor augue lobortis, nec eleifend velit venenatis. Nullam fringilla dui eget lectus mattis tincidunt. 
 <br />
@@ -169,7 +177,10 @@ Donec sollicitudin, lacus sed luctus ultricies, <s><em>quam sapien </em></s><str
     private $expected_multiple_unknown_attributes_image = '<p>Text 1 <strong>assumenda</strong> Text 2.
 
 </p>
-<p><img src="data:image/png;base64,ImageDataOmittedforSize" width="214" style="display: inline; float: right; margin: 0px 0px 1em 1em;" />Text 3.</p>';
+<p><img src="data:image/png;base64,ImageDataOmittedforSize" width="214" style="display: inline; float: right; margin: 0px 0px 1em 1em;" />
+
+</p>
+<p>Text 3.</p>';
 
     /**
      * Test for issue #64, opening p tag between two opening headers

--- a/src/Parser/Html.php
+++ b/src/Parser/Html.php
@@ -309,22 +309,19 @@ class Html extends Parse
     {
         $insert = $quill['insert'];
 
-        if (strlen(trim($insert)) > 0) {
+        /**
+         * @var Delta
+         */
+        $delta = new $this->class_delta_insert($insert, (array_key_exists('attributes', $quill) ? $quill['attributes'] : []));
 
-            /**
-             * @var Delta
-             */
-            $delta = new $this->class_delta_insert($insert, (array_key_exists('attributes', $quill) ? $quill['attributes'] : []));
-
-            if (preg_match("/[\n]{2,}/", $insert) !== 0) {
-                $delta->setClose();
-            } else {
-                if (preg_match("/[\n]{1}/", $insert) !== 0) {
-                    $delta->setNewLine();
-                }
+        if (preg_match("/[\n]{2,}/", $insert) !== 0) {
+            $delta->setClose();
+        } else {
+            if (preg_match("/[\n]{1}/", $insert) !== 0) {
+                $delta->setNewLine();
             }
-
-            $this->deltas[] = $delta;
         }
+
+        $this->deltas[] = $delta;
     }
 }


### PR DESCRIPTION
* Additional work to fix [#117](https://github.com/deanblackborough/php-quill-renderer/issues/117), allow through any empty insert, some are valid so for now just render what quill wants, I'll add strict mode later to remove what I consider to be the redundant inserts.