### PR TITLE
Fix github markdown not being mentioned as supported format

### DIFF
--- a/src/Options.php
+++ b/src/Options.php
@@ -16,6 +16,12 @@ class Options
     public const FORMAT_MARKDOWN = 'Markdown';
     public const FORMAT_GITHUB_MARKDOWN = 'GithubMarkdown'; // Github flavoured markdown
 
+    public const ALL_FORMATS = [
+        self::FORMAT_HTML,
+        self::FORMAT_MARKDOWN,
+        self::FORMAT_GITHUB_MARKDOWN,
+    ];
+
     public const GITHUB_MARKDOWN_TOKEN_STRIKE = '~~';
 
     public const HTML_TAG_BOLD = 'strong';

--- a/src/Render.php
+++ b/src/Render.php
@@ -46,10 +46,7 @@ class Render
             default:
                 throw new \InvalidArgumentException(
                     'Requested $format not supported, formats supported, ' .
-                    implode(
-                        ', ',
-                        [Options::FORMAT_HTML, OPTIONS::FORMAT_MARKDOWN]
-                    )
+                    implode(', ', Options::ALL_FORMATS)
                 );
                 break;
         }
@@ -89,10 +86,7 @@ class Render
                     // Shouldn't be possible to get here
                     throw new \InvalidArgumentException(
                         'Requested $format not supported, formats supported, ' .
-                        implode(
-                            ', ',
-                            [Options::FORMAT_HTML, OPTIONS::FORMAT_MARKDOWN]
-                        )
+                        implode(', ', Options::ALL_FORMATS)
                     );
                     break;
             }


### PR DESCRIPTION
I noticed the exception doesn't mention all formats and is easy to miss when adding another format.