### PR TITLE
Allow to pass already decoded json for increased performance

### DIFF
--- a/Tests/Api/StockTest.php
+++ b/Tests/Api/StockTest.php
@@ -14,6 +14,7 @@ final class StockTest extends \PHPUnit\Framework\TestCase
 {
     private $delta_null_insert = '{"ops":[{"insert":"Heading 1"},{"insert":null},{"attributes":{"header":1},"insert":"\n"}]}';
     private $delta_header = '{"ops":[{"insert":"Heading 1"},{"attributes":{"header":1},"insert":"\n"}]}';
+    private $delta_header_array = ["ops" => [["insert" => "Heading 1"], ["attributes" => ["header" => 1], "insert" => "\n"]]];
     private $delta_header_invalid = '{"ops":[{"insert":"Heading 1"},{"attributes":{"header":1},"insert":"\n"}}';
 
     private $expected_null_insert = "<h1>Heading 1</h1>";
@@ -74,6 +75,34 @@ final class StockTest extends \PHPUnit\Framework\TestCase
             $this->expected_header,
             trim($result),
             __METHOD__ . ' Multiple load calls failure'
+        );
+    }
+
+    /**
+     * Test passing an already decoded array of a json string. Load should not try to decode again.
+     * 
+     * @return void
+     * @throws \Exception
+     */
+    public function testLoadAlreadyDecoded()
+    {
+        $result = null;
+
+        $parser = new \DBlackborough\Quill\Parser\Html();
+
+        try {
+            $parser->load($this->delta_header_array)->parse();
+
+            $renderer = new \DBlackborough\Quill\Renderer\Html();
+            $result = $renderer->load($parser->deltas())->render();
+        } catch (\Exception $e) {
+            $this->fail(__METHOD__ . 'failure, ' . $e->getMessage());
+        }
+
+        $this->assertEquals(
+            $this->expected_header,
+            trim($result),
+            __METHOD__ . ' Array load call failure'
         );
     }
 

--- a/src/Interfaces/ParserInterface.php
+++ b/src/Interfaces/ParserInterface.php
@@ -18,19 +18,19 @@ interface ParserInterface
      * Load the deltas string, checks the json is valid and can be decoded
      * and then saves the decoded array to the the $quill_json property
      *
-     * @param string $quill_json Quill json string
+     * @param array|string $quill_json Quill json string
      *
      * @return Parse
      * @throws \InvalidArgumentException Throws an exception if there was an error decoding the json
      */
-    public function load(string $quill_json): Parse;
+    public function load($quill_json): Parse;
 
     /**
      * Load multiple delta strings, checks the json is valid for each index,
      * ensures they can be decoded and the saves each decoded array to the
      * $quill_json_stack property indexed by the given key
      *
-     * @param array An array of $quill json strings, returnable via array index
+     * @param array An array of $quill json array|strings, returnable via array index
      *
      * @return Parse
      * @throws \InvalidArgumentException Throws an exception if there was an error decoding the json

--- a/src/Parser/Parse.php
+++ b/src/Parser/Parse.php
@@ -74,14 +74,17 @@ abstract class Parse implements ParserInterface, ParserAttributeInterface
      * Load the deltas string, checks the json is valid and can be decoded
      * and then saves the decoded array to the the $quill_json property
      *
-     * @param string $quill_json Quill json string
+     * @param array|string $quill_json Quill json string
      *
      * @return Parse
      * @throws \InvalidArgumentException Throws an exception if there was an error decoding the json
      */
-    public function load(string $quill_json): Parse
+    public function load($quill_json): Parse
     {
-        $this->quill_json = json_decode($quill_json, true);
+        $this->quill_json = $quill_json;
+        if (is_string($this->quill_json) === true) {
+            $this->quill_json = json_decode($quill_json, true);
+        }
 
         if (is_array($this->quill_json) === true && count($this->quill_json) > 0) {
             $this->valid = true;
@@ -97,7 +100,7 @@ abstract class Parse implements ParserInterface, ParserAttributeInterface
      * ensures they can be decoded and the saves each decoded array to the
      * $quill_json_stack property indexed by the given key
      *
-     * @param array An array of $quill json strings, returnable via array index
+     * @param array An array of $quill json arrays|strings, returnable via array index
      *
      * @return Parse
      * @throws \InvalidArgumentException Throws an exception if there was an error decoding the json
@@ -106,8 +109,10 @@ abstract class Parse implements ParserInterface, ParserAttributeInterface
     {
         $this->deltas_stack = [];
 
-        foreach ($quill_json as $index => $json) {
-            $json_stack_value = json_decode($json, true);
+        foreach ($quill_json as $index => $json_stack_value) {
+            if (is_string($json_stack_value) === true) {
+                $json_stack_value = json_decode($json_stack_value, true);
+            }
 
             if (is_array($json_stack_value) === true && count($json_stack_value) > 0) {
                 $this->quill_json_stack[$index] = $json_stack_value;


### PR DESCRIPTION
In our use case we have delta already as an array coming out of an database. To be able to pass it for rendering we had to encode it again, even though the string variant is not used and directly decoded. That feels a bit of a waste. And it helps performance, especially in larger documents, to not have to do this.

The sad thing is that I removed the type hint. I can also add a method next to this having an array type hint, but personally I don't care. I could change though if that is wanted.